### PR TITLE
Throw exception if unsupported type

### DIFF
--- a/Refractored.MvxPlugins.Settings.Droid/MvxAndroidSettings.cs
+++ b/Refractored.MvxPlugins.Settings.Droid/MvxAndroidSettings.cs
@@ -123,6 +123,8 @@ namespace Refractored.MvxPlugins.Settings.Droid
                     case TypeCode.DateTime:
                         SharedPreferencesEditor.PutLong(key, ((DateTime)(object)value).Ticks);
                         break;
+                    default:
+                        throw new ArgumentException(string.Format("Value of type {0} is not supported.", value.GetType().Name));
                 }
             }
 

--- a/Refractored.MvxPlugins.Settings.Touch/MvxTouchSettings.cs
+++ b/Refractored.MvxPlugins.Settings.Touch/MvxTouchSettings.cs
@@ -129,6 +129,8 @@ namespace Refractored.MvxPlugins.Settings.Touch
                     case TypeCode.DateTime:
                         defaults.SetString(Convert.ToString(((DateTime)(object)value).Ticks), key);
                         break;
+                    default:
+                        throw new ArgumentException(string.Format("Value of type {0} is not supported.", value.GetType().Name));
                 }
             }
 


### PR DESCRIPTION
When trying to save an unsupported type, the plugin would currently report `true` while nothing was in fact saved. It would be better to explicitly fail, as it would most likely be a bug in the app.
