### PR TITLE
fix iOSUnified PCL target location

### DIFF
--- a/Common/MvxPluginsSettings.nuspec
+++ b/Common/MvxPluginsSettings.nuspec
@@ -78,8 +78,8 @@
      <!--Xamarin.iOSUnified-->
      <file src="..\Refractored.MvxPlugins.Settings.TouchUnified\bin\iPhone\Release\Refractored.MvxPlugins.Settings.TouchUnified.dll" target="lib\Xamarin.iOS10\Refractored.MvxPlugins.Settings.TouchUnified.dll" />
      <file src="..\Refractored.MvxPlugins.Settings.TouchUnified\bin\iPhone\Release\Refractored.MvxPlugins.Settings.TouchUnified.xml" target="lib\Xamarin.iOS10\Refractored.MvxPlugins.Settings.TouchUnified.xml" />
-     <file src="..\Refractored.MvxPlugins.Settings\bin\Release\Refractored.MvxPlugins.Settings.dll" target="lib\monotouch\Refractored.MvxPlugins.Settings.dll" />
-     <file src="..\Refractored.MvxPlugins.Settings\bin\Release\Refractored.MvxPlugins.Settings.xml" target="lib\monotouch\Refractored.MvxPlugins.Settings.xml" />
+     <file src="..\Refractored.MvxPlugins.Settings\bin\Release\Refractored.MvxPlugins.Settings.dll" target="lib\Xamarin.iOS10\Refractored.MvxPlugins.Settings.dll" />
+     <file src="..\Refractored.MvxPlugins.Settings\bin\Release\Refractored.MvxPlugins.Settings.xml" target="lib\Xamarin.iOS10\Refractored.MvxPlugins.Settings.xml" />
      <file src="monotouch\SettingsPluginBootstrap.cs.pp" target="content\Xamarin.iOS10\Bootstrap\SettingsPluginBootstrap.cs.pp" />
      <file src="core\_SettingsStarted.txt.pp" target="content\Xamarin.iOS10\Properties\_SettingsStarted.txt.pp" />
 


### PR DESCRIPTION
I've tried 1.4.0.3 NuGet package for my iOS project but PCL assembly does not reference from project.
iOSUnified section on nuspec, PCL assembly targeted for `monotouch`. This PR fix it for `Xamarin.iOS10`.
